### PR TITLE
Bandwidth stats and DPI scaling fix

### DIFF
--- a/html5/index.html
+++ b/html5/index.html
@@ -723,7 +723,7 @@
 				const toolbar_position = getparam("toolbar_position");
 				const autohide = getboolparam("autohide", false);
 				const override_width = getfloatparam("override_width", window.innerWidth);
-				const device_dpi_scaling = (default_settings["device_dpi_scaling"] || "false").toLowerCase() === "true";
+				const device_dpi_scaling = getboolparam("device_dpi_scaling",false);
 				vrefresh = getintparam("vrefresh", -1);
 				if (vrefresh<0 && fps>=30) {
 					vrefresh = fps;
@@ -750,7 +750,6 @@
 						scale = override_width/window.innerWidth;
 					}
 				}
-				scale = Math.round(scale);
 
 				let progress_timer;
 				const progress_value = 0;

--- a/html5/index.html
+++ b/html5/index.html
@@ -151,7 +151,7 @@
 								<a href="#" data-icon="visibility_off" class="autohide_menu" onclick="toggle_menu_auto_hide()">Auto Hide Menu</a>
 							</li>
 							<li>
-								<a href="#" data-icon="wifi" onclick="show_sessioninfo(event)">Session Info</a>
+								<a href="#" data-icon="wifi" id="window_tray_bandwidth" onclick="show_sessioninfo(event)">Session Info</a>
 							</li>
 							<li>
 								<a href="#" data-icon="refresh" onclick="location.reload()">Reload</a>
@@ -275,6 +275,10 @@
 				<td id="server_platform"></td>
 			</tr>
 			-->
+			<tr>
+				<th scope="row">Bandwidth (Up/Down)</th>
+				<td id="session_info_bandwidth"></td>
+			</tr>
 			<tr>
 				<th scope="row">Server Load</th>
 				<td id="server_load"></td>
@@ -1535,6 +1539,24 @@
 						client.last_key_packet = [];
 					}
 				});
+
+				// Calculate protocol bandwith stats.
+				client.on_open = (e) => {
+					var bw_stats_start_time_ms = new Date().getTime();
+					var bw_stats_last_inbound_traffic = client.protocol.inbound_traffic;
+					var bw_stats_last_outbound_traffic = client.protocol.outbound_traffic;
+					setInterval(() => {
+						var curr_time_ms = new Date().getTime();
+						var delta_t = ((curr_time_ms - bw_stats_start_time_ms) / 1000);
+						var inbound_rate_s = parseInt( ((client.protocol.inbound_traffic - bw_stats_last_inbound_traffic)/125) / delta_t);
+						bw_stats_last_inbound_traffic = client.protocol.inbound_traffic;
+						var outbound_rate_s = parseInt( ((client.protocol.outbound_traffic - bw_stats_last_outbound_traffic)/125) / delta_t);
+						bw_stats_last_outbound_traffic = client.protocol.outbound_traffic;
+						bw_stats_start_time_ms = curr_time_ms;
+						$('#window_tray_bandwidth').text(`${inbound_rate_s} kbits/s`);
+						$('#session_info_bandwidth').text(`${outbound_rate_s} / ${inbound_rate_s} kbits/s`);
+					}, 1000);
+				}
 			}
 
 			$(document).ready(function() {

--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -1084,21 +1084,16 @@ XpraClient.prototype._get_desktop_size = function() {
 };
 
 XpraClient.prototype._get_DPI = function() {
-	if (window.devicePixelRatio !== undefined) {
-		return Math.round(96 * devicePixelRatio);
-	}
-	"use strict";
+	var dpi = 96;
 	const dpi_div = document.getElementById("dpi");
 	if (dpi_div != undefined) {
 		//show("dpiX="+dpi_div.offsetWidth+", dpiY="+dpi_div.offsetHeight);
 		if (dpi_div.offsetWidth>0 && dpi_div.offsetHeight>0)
-			return Math.round((dpi_div.offsetWidth + dpi_div.offsetHeight) / 2.0);
+			dpi = (dpi_div.offsetWidth + dpi_div.offsetHeight) / 2.0;
+	} else if ('deviceXDPI' in screen) {
+		dpi = (screen.systemXDPI + screen.systemYDPI) / 2;
 	}
-	//alternative:
-	if ('deviceXDPI' in screen)
-		return (screen.systemXDPI + screen.systemYDPI) / 2;
-	//default:
-	return 96;
+	return Math.round(dpi * client.scale);
 };
 
 XpraClient.prototype._get_screen_sizes = function() {

--- a/html5/js/Window.js
+++ b/html5/js/Window.js
@@ -276,7 +276,7 @@ function XpraWindow(client, canvas_state, wid, x, y, w, h, metadata, override_re
 				const dy = ev.offsetY-me.pointer_last_y;
 				me.pointer_last_x = ev.offsetX;
 				me.pointer_last_y = ev.offsetY;
-				const mult = 20.0*(window.devicePixelRatio || 1);
+				const mult = 20.0*(client.scale || 1);
 				ev.wheelDeltaX = Math.round(dx*mult);
 				ev.wheelDeltaY = Math.round(dy*mult);
 				on_mousescroll(ev);
@@ -1141,11 +1141,11 @@ XpraWindow.prototype.set_cursor = function(encoding, w, h, xhot, yhot, img_data)
 			const canvas = document.createElement('canvas');
 			const ctx = canvas.getContext('2d');
 			ctx.imageSmoothingEnabled = false;
-			canvas.width = Math.round(w*window.devicePixelRatio);
-			canvas.height = Math.round(h*window.devicePixelRatio);
+			canvas.width = Math.round(w*client.scale);
+			canvas.height = Math.round(h*client.scale);
 			ctx.drawImage(this, 0, 0, canvas.width, canvas.height);
 			var scaled_cursor_url = canvas.toDataURL();
-			set_cursor_url(scaled_cursor_url, Math.round(xhot*window.devicePixelRatio), Math.round(yhot*window.devicePixelRatio));
+			set_cursor_url(scaled_cursor_url, Math.round(xhot*client.scale), Math.round(yhot*client.scale));
 		};
 		tmp_img.src = cursor_url;
 	}


### PR DESCRIPTION
- Add bandwidth statistics feature to websocket.
- Add download bandwidth to window tray icon.
![image](https://user-images.githubusercontent.com/323725/155857431-f4ebd96c-02e3-47bd-adea-a0f95b551004.png)
- Add up/down stats to session info overlay.
![image](https://user-images.githubusercontent.com/323725/155857477-79ccd1d2-4dfc-436a-8f0a-05151b63f378.png)

- Fix scaling issue with DPI, use `client.scale` instead of `window.devicePixelRatio` everywhere so that hidpi can be properly disabled without over-scaling.